### PR TITLE
Don't remove original files if --stdout option is used

### DIFF
--- a/lmod/bin/gunziplua.lua
+++ b/lmod/bin/gunziplua.lua
@@ -122,8 +122,10 @@ local function call(...)
         disable_crc=options.disable_crc}
     end
 
-    for _,gzipfile in ipairs(gzipfiles) do
-      assert(os.remove(gzipfile))
+    if not options.stdout then
+      for _,gzipfile in ipairs(gzipfiles) do
+        assert(os.remove(gzipfile))
+      end
     end
 
   end, debug_traceback)


### PR DESCRIPTION
When I use the command:

```
$ bin/gunziplua --stdout lua-5.1.5.tar.gz > /dev/null
```

gunziplua deletes the original file, despite the usage info stating:

> -c, --stdout   write on standard output, keep original files unchanged

This patch fixes the disparity, in favour of the usage info.
